### PR TITLE
Handle missing optional PostCSS plugins

### DIFF
--- a/.postcssrc.js
+++ b/.postcssrc.js
@@ -1,10 +1,52 @@
-// https://github.com/michael-ciniawsky/postcss-load-config
+import { createRequire } from 'node:module';
 
-module.exports = {
-  "plugins": {
-    "postcss-import": {},
-    "postcss-url": {},
-    // to edit target browsers: use "browserslist" field in package.json
-    "autoprefixer": {}
+const require = createRequire(import.meta.url);
+
+const OPTIONAL_PLUGINS = [
+  { name: 'postcss-import' },
+  { name: 'postcss-url' },
+  { name: 'autoprefixer' },
+];
+
+function resolvePlugin({ name, options = {} }) {
+  try {
+    let plugin = require(name);
+
+    if (plugin && typeof plugin === 'object' && 'default' in plugin) {
+      plugin = plugin.default;
+    }
+
+    if (typeof plugin === 'function') {
+      return plugin(options);
+    }
+
+    return plugin ?? null;
+  } catch (error) {
+    if (isModuleNotFoundError(error, name)) {
+      console.warn(`[postcss] Optional plugin "${name}" is not installed. Skipping.`);
+      return null;
+    }
+
+    throw error;
   }
 }
+
+function isModuleNotFoundError(error, moduleName) {
+  if (!error || typeof error !== 'object') {
+    return false;
+  }
+
+  const { code, message } = error;
+
+  if (code !== 'MODULE_NOT_FOUND' && code !== 'ERR_MODULE_NOT_FOUND') {
+    return false;
+  }
+
+  return typeof message === 'string' && message.includes(moduleName);
+}
+
+const plugins = OPTIONAL_PLUGINS.map(resolvePlugin).filter(Boolean);
+
+export default {
+  plugins,
+};


### PR DESCRIPTION
## Summary
- update the PostCSS config to load optional plugins only when they are installed so Vite can start without them

## Testing
- not run (npm registry access is blocked in the environment)


------
https://chatgpt.com/codex/tasks/task_e_68c93673fab08320adc0f25cd43b91f7